### PR TITLE
Add default export of plugin

### DIFF
--- a/remark-inline-spoiler/src/index.ts
+++ b/remark-inline-spoiler/src/index.ts
@@ -24,7 +24,7 @@ export interface SpoilerPluginOptions {
   // add extra options here, in addition to those for the syntax extension
 }
 
-export function spoilerPlugin(this: any, options: Partial<SpoilerPluginOptions> = {}) {
+export default function spoilerPlugin(this: any, options: Partial<SpoilerPluginOptions> = {}) {
   var data = this.data();
 
   // warn for earlier versions

--- a/remark-inline-spoiler/src/index.ts
+++ b/remark-inline-spoiler/src/index.ts
@@ -24,7 +24,7 @@ export interface SpoilerPluginOptions {
   // add extra options here, in addition to those for the syntax extension
 }
 
-export default function spoilerPlugin(this: any, options: Partial<SpoilerPluginOptions> = {}) {
+export function spoilerPlugin(this: any, options: Partial<SpoilerPluginOptions> = {}) {
   var data = this.data();
 
   // warn for earlier versions
@@ -39,3 +39,5 @@ export default function spoilerPlugin(this: any, options: Partial<SpoilerPluginO
     else data[field] = [value];
   }
 }
+
+export default spoilerPlugin;


### PR DESCRIPTION
To follow the convention.

...and to allow auto importers to import this library correctly (such as nuxt/content).

https://github.com/benrbray/remark-cite/blob/3957777e06b394f6d6d824cadf290a1ec54ac279/remark-cite/lib/main.ts#L26